### PR TITLE
add mongodump cronjob

### DIFF
--- a/kubernetes/overlays/prod/kustomization.yaml
+++ b/kubernetes/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - kafka-messagebus.yaml
 - ingress.yaml
 - cryoem-storage.yaml
+- mongodump.yaml
 
 patchesStrategicMerge:
 - auth-patches.yaml

--- a/kubernetes/overlays/prod/mongodump-by-db.sh
+++ b/kubernetes/overlays/prod/mongodump-by-db.sh
@@ -1,130 +1,216 @@
 #!/bin/bash
 #
 # mongodump-by-db.sh
-# Dumps each MongoDB database individually via mongos.
-# Designed to run inside the "restore" pod in the cryoem-logbook namespace.
+# Dumps each MongoDB database individually, connecting directly to rs0-0.
+# Designed to run inside the mongodb-logic-backup pod in cryoem-logbook namespace.
 #
 # Usage:
 #   ./mongodump-by-db.sh                          # dump all user databases
 #   ./mongodump-by-db.sh mydb1 mydb2              # dump only specific databases
 #
 # Environment variables (override defaults):
-#   MONGO_HOST        mongos host          (default: mongo-mongos.cryoem-logbook.svc.cluster.local)
-#   MONGO_PORT        mongos port          (default: 27017)
-#   MONGO_USER        auth username         (default: admin)
-#   MONGO_PASS        auth password         (read from secret file or set directly)
-#   MONGO_AUTH_DB     auth database         (default: admin)
-#   DUMP_ROOT         output directory      (default: /data/mongodump)
-#   GZIP              enable gzip           (default: true)
-#   PARALLEL          parallel collections  (default: 4)
+#   MONGO_HOST    mongo host     (default: mongo-rs0-0.mongo-rs0)
+#   MONGO_PORT    mongo port     (default: 27017)
+#   MONGO_USER    username       (default: backup)
+#   MONGO_PASS    password       (required)
+#   MONGO_AUTH_DB auth database  (default: admin)
+#   DUMP_ROOT     output dir     (default: /data/mongodump)
+#   RETAIN_DAYS   days to keep   (default: 14)
+#   GZIP          gzip output    (default: true)
+#   PARALLEL      parallel cols  (default: 4)
+#   VERBOSE       verbose output (default: true)
 
 set -euo pipefail
 
 # --- configuration -----------------------------------------------------------
-MONGO_HOST="${MONGO_HOST:-mongo-mongos.cryoem-logbook.svc.cluster.local}"
+MONGO_HOST="${MONGO_HOST:-mongo-rs0-0.mongo-rs0}"
 MONGO_PORT="${MONGO_PORT:-27017}"
-MONGO_USER="${MONGO_USER:-admin}"
+MONGO_USER="${MONGO_USER:-backup}"
 MONGO_PASS="${MONGO_PASS:-}"
 MONGO_AUTH_DB="${MONGO_AUTH_DB:-admin}"
 DUMP_ROOT="${DUMP_ROOT:-/data/mongodump}"
+RETAIN_DAYS="${RETAIN_DAYS:-14}"
 GZIP="${GZIP:-true}"
 PARALLEL="${PARALLEL:-4}"
+VERBOSE="${VERBOSE:-true}"
 
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 DUMP_DIR="${DUMP_ROOT}/${TIMESTAMP}"
 
-# databases to skip (system databases)
 SKIP_DBS="admin|config|local"
 
 # --- helpers ------------------------------------------------------------------
 log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
-die()  { log "ERROR: $*" >&2; exit 1; }
+warn() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARN: $*" >&2; }
+die()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $*" >&2; exit 1; }
+
+# --- banner -------------------------------------------------------------------
+log "========== mongodump-by-db starting =========="
+log "  Host     : ${MONGO_HOST}:${MONGO_PORT}"
+log "  User     : ${MONGO_USER}"
+log "  Auth DB  : ${MONGO_AUTH_DB}"
+log "  Dump root: ${DUMP_ROOT}"
+log "  Retain   : ${RETAIN_DAYS} days"
+log "  Gzip     : ${GZIP}"
+log "  Parallel : ${PARALLEL}"
+log "  Verbose  : ${VERBOSE}"
+log "==============================================="
 
 # --- pre-flight checks -------------------------------------------------------
-command -v mongodump >/dev/null 2>&1 || die "mongodump not found in PATH"
-command -v mongosh  >/dev/null 2>&1 || MONGOSH="mongo" || true
-MONGOSH="${MONGOSH:-mongosh}"
+log "Checking tools..."
+command -v mongodump >/dev/null 2>&1 \
+  && log "  mongodump: $(mongodump --version 2>&1 | head -1)" \
+  || die "mongodump not found in PATH"
 
-if [[ -z "${MONGO_PASS}" ]]; then
-  # try reading from the Percona-generated secret mounted path
-  SECRET_FILE="/etc/mongodb-secrets/MONGODB_CLUSTER_ADMIN_PASSWORD"
-  if [[ -f "${SECRET_FILE}" ]]; then
-    MONGO_PASS="$(cat "${SECRET_FILE}")"
-    log "Read password from ${SECRET_FILE}"
-  else
-    die "MONGO_PASS not set and ${SECRET_FILE} not found. Export MONGO_PASS or mount the secret."
-  fi
+if command -v mongo >/dev/null 2>&1; then
+  MONGOSH="mongo"
+  log "  shell: $(mongo --version 2>&1 | head -1)"
+else
+  die "mongo shell not found in PATH"
 fi
 
-CONN_URI="mongodb://${MONGO_USER}:${MONGO_PASS}@${MONGO_HOST}:${MONGO_PORT}/?authSource=${MONGO_AUTH_DB}"
+# --- password resolution ------------------------------------------------------
+if [[ -z "${MONGO_PASS}" ]]; then
+  die "MONGO_PASS not set. Run: env MONGO_PASS=xxx bash $0"
+fi
+
+# --- connection args (simple flag format) ------------------------------------
+CONN_ARGS=(
+  -u "${MONGO_USER}"
+  -p "${MONGO_PASS}"
+  --authenticationDatabase="${MONGO_AUTH_DB}"
+  --host "${MONGO_HOST}"
+  --port "${MONGO_PORT}"
+)
+
+# --- test connectivity --------------------------------------------------------
+log "Testing TCP connectivity to ${MONGO_HOST}:${MONGO_PORT} ..."
+if nc -z -w5 "${MONGO_HOST}" "${MONGO_PORT}" 2>/dev/null; then
+  log "  TCP: OK"
+else
+  warn "  TCP: FAILED — host may be unreachable"
+fi
+
+log "Testing MongoDB authentication..."
+AUTH_TEST=$("${MONGOSH}" "${CONN_ARGS[@]}" --quiet \
+  --eval 'rs.slaveOk(); db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' \
+  2>&1) || true
+log "  Auth result: ${AUTH_TEST}"
+
+if echo "${AUTH_TEST}" | grep -qi "error\|failed\|refused\|closed"; then
+  die "Authentication failed. Check MONGO_USER and MONGO_PASS."
+fi
 
 # --- resolve database list ----------------------------------------------------
 if [[ $# -gt 0 ]]; then
-  DATABASES=("$@")
+  DATABASES=()
+  for db in "$@"; do
+    if echo "${db}" | grep -qwE "${SKIP_DBS}"; then
+      log "Skipping excluded db: ${db}"
+    else
+      DATABASES+=("${db}")
+    fi
+  done
+  [[ ${#DATABASES[@]} -eq 0 ]] && die "No databases to dump after exclusions"
   log "Dumping specified databases: ${DATABASES[*]}"
 else
-  log "Listing databases from ${MONGO_HOST}:${MONGO_PORT} ..."
-  DB_LIST=$("${MONGOSH}" --quiet --eval '
-    db.adminCommand({ listDatabases: 1, nameOnly: true })
-      .databases.map(d => d.name).join("\n")
-  ' "${CONN_URI}") || die "Failed to list databases"
+  log "Listing all databases (this may take a while) ..."
+  DB_LIST_RAW=$("${MONGOSH}" "${CONN_ARGS[@]}" --quiet --eval '
+    try {
+      rs.slaveOk();
+      var r = db.adminCommand({ listDatabases: 1, nameOnly: true });
+      if (r.ok) {
+        print("DB_COUNT: " + r.databases.length);
+        r.databases.forEach(function(d) { print(d.name); });
+        print("DB_LIST_DONE");
+      } else {
+        print("CMD_ERROR: " + JSON.stringify(r));
+      }
+    } catch(e) { print("EXCEPTION: " + e.message); }
+  ' 2>&1)
 
-  # filter out system dbs
+  log "  Raw output:"
+  echo "${DB_LIST_RAW}" | while IFS= read -r line; do log "    | ${line}"; done
+
+  if echo "${DB_LIST_RAW}" | grep -q "EXCEPTION\|CMD_ERROR\|Error"; then
+    die "Failed to list databases."
+  fi
+
   DATABASES=()
   while IFS= read -r db; do
+    db="$(echo "${db}" | tr -d '[:space:]')"
     [[ -z "${db}" ]] && continue
-    if echo "${db}" | grep -qwE "${SKIP_DBS}"; then
-      log "  skipping system db: ${db}"
-      continue
-    fi
+    echo "${db}" | grep -qwE "${SKIP_DBS}" && { log "  Skipping: ${db}"; continue; }
+    echo "${db}" | grep -qE "^DB_COUNT:|^DB_LIST_DONE$" && continue
     DATABASES+=("${db}")
-  done <<< "${DB_LIST}"
+  done <<< "${DB_LIST_RAW}"
 
-  if [[ ${#DATABASES[@]} -eq 0 ]]; then
-    die "No user databases found to dump"
-  fi
+  [[ ${#DATABASES[@]} -eq 0 ]] && die "No user databases found"
   log "Found ${#DATABASES[@]} databases: ${DATABASES[*]}"
 fi
 
 # --- dump each database -------------------------------------------------------
 mkdir -p "${DUMP_DIR}"
+log "Output directory: ${DUMP_DIR}"
+
 FAILED=()
 SUCCEEDED=()
+TOTAL=${#DATABASES[@]}
+COUNT=0
 
 for db in "${DATABASES[@]}"; do
+  COUNT=$((COUNT + 1))
   OUT_DIR="${DUMP_DIR}/${db}"
-  log "Dumping '${db}' → ${OUT_DIR} ..."
+  LOG_FILE="${DUMP_DIR}/${db}.log"
+  log ""
+  log "[${COUNT}/${TOTAL}] Dumping '${db}' → ${OUT_DIR} ..."
 
   DUMP_ARGS=(
-    --uri="${CONN_URI}"
+    "${CONN_ARGS[@]}"
     --db="${db}"
     --out="${OUT_DIR}"
     --numParallelCollections="${PARALLEL}"
     --readPreference=secondaryPreferred
   )
+  [[ "${GZIP}"    == "true" ]] && DUMP_ARGS+=(--gzip)
+  [[ "${VERBOSE}" == "true" ]] && DUMP_ARGS+=(-v)
 
-  if [[ "${GZIP}" == "true" ]]; then
-    DUMP_ARGS+=(--gzip)
-  fi
-
-  if mongodump "${DUMP_ARGS[@]}" 2>&1 | tee "${OUT_DIR}.log"; then
+  START_SEC=$(date +%s)
+  if mongodump "${DUMP_ARGS[@]}" 2>&1 | tee "${LOG_FILE}"; then
+    ELAPSED=$(( $(date +%s) - START_SEC ))
+    DUMP_SIZE=$(du -sh "${OUT_DIR}" 2>/dev/null | cut -f1 || echo "unknown")
     SUCCEEDED+=("${db}")
-    log "  ✓ ${db} done"
+    log "  OK  ${db} — ${ELAPSED}s, ${DUMP_SIZE}"
   else
+    ELAPSED=$(( $(date +%s) - START_SEC ))
     FAILED+=("${db}")
-    log "  ✗ ${db} FAILED (see ${OUT_DIR}.log)"
+    log "  FAIL  ${db} — ${ELAPSED}s (see ${LOG_FILE})"
   fi
 done
 
 # --- summary ------------------------------------------------------------------
-echo ""
+log ""
 log "========== DUMP SUMMARY =========="
 log "  Timestamp : ${TIMESTAMP}"
 log "  Output    : ${DUMP_DIR}"
+log "  Total     : ${TOTAL}"
 log "  Succeeded : ${#SUCCEEDED[@]} — ${SUCCEEDED[*]:-none}"
 log "  Failed    : ${#FAILED[@]} — ${FAILED[*]:-none}"
+log "  Total size: $(du -sh "${DUMP_DIR}" 2>/dev/null | cut -f1 || echo unknown)"
 log "=================================="
 
-if [[ ${#FAILED[@]} -gt 0 ]]; then
-  exit 1
+# --- cleanup old dumps --------------------------------------------------------
+log ""
+log "Cleaning up dumps older than ${RETAIN_DAYS} days in ${DUMP_ROOT} ..."
+OLD_DUMPS=$(find "${DUMP_ROOT}" -maxdepth 1 -mindepth 1 -type d -mtime "+${RETAIN_DAYS}" 2>/dev/null || true)
+if [[ -z "${OLD_DUMPS}" ]]; then
+  log "  Nothing to clean up."
+else
+  while IFS= read -r old_dir; do
+    log "  Removing: ${old_dir}"
+    rm -rf "${old_dir}"
+  done <<< "${OLD_DUMPS}"
+  log "  Cleanup done."
 fi
+
+[[ ${#FAILED[@]} -gt 0 ]] && exit 1 || exit 0

--- a/kubernetes/overlays/prod/mongodump-by-db.sh
+++ b/kubernetes/overlays/prod/mongodump-by-db.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# mongodump-by-db.sh
+# Dumps each MongoDB database individually via mongos.
+# Designed to run inside the "restore" pod in the cryoem-logbook namespace.
+#
+# Usage:
+#   ./mongodump-by-db.sh                          # dump all user databases
+#   ./mongodump-by-db.sh mydb1 mydb2              # dump only specific databases
+#
+# Environment variables (override defaults):
+#   MONGO_HOST        mongos host          (default: mongo-mongos.cryoem-logbook.svc.cluster.local)
+#   MONGO_PORT        mongos port          (default: 27017)
+#   MONGO_USER        auth username         (default: admin)
+#   MONGO_PASS        auth password         (read from secret file or set directly)
+#   MONGO_AUTH_DB     auth database         (default: admin)
+#   DUMP_ROOT         output directory      (default: /data/mongodump)
+#   GZIP              enable gzip           (default: true)
+#   PARALLEL          parallel collections  (default: 4)
+
+set -euo pipefail
+
+# --- configuration -----------------------------------------------------------
+MONGO_HOST="${MONGO_HOST:-mongo-mongos.cryoem-logbook.svc.cluster.local}"
+MONGO_PORT="${MONGO_PORT:-27017}"
+MONGO_USER="${MONGO_USER:-admin}"
+MONGO_PASS="${MONGO_PASS:-}"
+MONGO_AUTH_DB="${MONGO_AUTH_DB:-admin}"
+DUMP_ROOT="${DUMP_ROOT:-/data/mongodump}"
+GZIP="${GZIP:-true}"
+PARALLEL="${PARALLEL:-4}"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+DUMP_DIR="${DUMP_ROOT}/${TIMESTAMP}"
+
+# databases to skip (system databases)
+SKIP_DBS="admin|config|local"
+
+# --- helpers ------------------------------------------------------------------
+log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+die()  { log "ERROR: $*" >&2; exit 1; }
+
+# --- pre-flight checks -------------------------------------------------------
+command -v mongodump >/dev/null 2>&1 || die "mongodump not found in PATH"
+command -v mongosh  >/dev/null 2>&1 || MONGOSH="mongo" || true
+MONGOSH="${MONGOSH:-mongosh}"
+
+if [[ -z "${MONGO_PASS}" ]]; then
+  # try reading from the Percona-generated secret mounted path
+  SECRET_FILE="/etc/mongodb-secrets/MONGODB_CLUSTER_ADMIN_PASSWORD"
+  if [[ -f "${SECRET_FILE}" ]]; then
+    MONGO_PASS="$(cat "${SECRET_FILE}")"
+    log "Read password from ${SECRET_FILE}"
+  else
+    die "MONGO_PASS not set and ${SECRET_FILE} not found. Export MONGO_PASS or mount the secret."
+  fi
+fi
+
+CONN_URI="mongodb://${MONGO_USER}:${MONGO_PASS}@${MONGO_HOST}:${MONGO_PORT}/?authSource=${MONGO_AUTH_DB}"
+
+# --- resolve database list ----------------------------------------------------
+if [[ $# -gt 0 ]]; then
+  DATABASES=("$@")
+  log "Dumping specified databases: ${DATABASES[*]}"
+else
+  log "Listing databases from ${MONGO_HOST}:${MONGO_PORT} ..."
+  DB_LIST=$("${MONGOSH}" --quiet --eval '
+    db.adminCommand({ listDatabases: 1, nameOnly: true })
+      .databases.map(d => d.name).join("\n")
+  ' "${CONN_URI}") || die "Failed to list databases"
+
+  # filter out system dbs
+  DATABASES=()
+  while IFS= read -r db; do
+    [[ -z "${db}" ]] && continue
+    if echo "${db}" | grep -qwE "${SKIP_DBS}"; then
+      log "  skipping system db: ${db}"
+      continue
+    fi
+    DATABASES+=("${db}")
+  done <<< "${DB_LIST}"
+
+  if [[ ${#DATABASES[@]} -eq 0 ]]; then
+    die "No user databases found to dump"
+  fi
+  log "Found ${#DATABASES[@]} databases: ${DATABASES[*]}"
+fi
+
+# --- dump each database -------------------------------------------------------
+mkdir -p "${DUMP_DIR}"
+FAILED=()
+SUCCEEDED=()
+
+for db in "${DATABASES[@]}"; do
+  OUT_DIR="${DUMP_DIR}/${db}"
+  log "Dumping '${db}' → ${OUT_DIR} ..."
+
+  DUMP_ARGS=(
+    --uri="${CONN_URI}"
+    --db="${db}"
+    --out="${OUT_DIR}"
+    --numParallelCollections="${PARALLEL}"
+    --readPreference=secondaryPreferred
+  )
+
+  if [[ "${GZIP}" == "true" ]]; then
+    DUMP_ARGS+=(--gzip)
+  fi
+
+  if mongodump "${DUMP_ARGS[@]}" 2>&1 | tee "${OUT_DIR}.log"; then
+    SUCCEEDED+=("${db}")
+    log "  ✓ ${db} done"
+  else
+    FAILED+=("${db}")
+    log "  ✗ ${db} FAILED (see ${OUT_DIR}.log)"
+  fi
+done
+
+# --- summary ------------------------------------------------------------------
+echo ""
+log "========== DUMP SUMMARY =========="
+log "  Timestamp : ${TIMESTAMP}"
+log "  Output    : ${DUMP_DIR}"
+log "  Succeeded : ${#SUCCEEDED[@]} — ${SUCCEEDED[*]:-none}"
+log "  Failed    : ${#FAILED[@]} — ${FAILED[*]:-none}"
+log "=================================="
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  exit 1
+fi

--- a/kubernetes/overlays/prod/mongodump.yaml
+++ b/kubernetes/overlays/prod/mongodump.yaml
@@ -1,0 +1,51 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mongo-restore-logic
+spec:
+  storageClassName: wekafs--sdf-k8s01
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1000Gi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb-logic-backup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo-restore
+  template:
+    metadata:
+      labels:
+        app: mongo-restore
+    spec:
+      containers:
+      - name: mongo-restore
+        image: mongo:5.0
+        command: [ "bash", "-c", "sleep infinity" ]
+        volumeMounts:
+        - mountPath: /data
+          name: mongo-restore
+        - mountPath: /etc/mongo-ssl
+          name: mongo-ssl
+          readOnly: true
+      - name: scp
+        image: kroniak/ssh-client
+        command:  [ "bash", "-c", "sleep infinity" ]
+        volumeMounts:
+        - mountPath: /data
+          name: mongo-restore
+      volumes:
+      - name: mongo-restore
+        persistentVolumeClaim:
+          claimName: mongo-restore-logic 
+      - name: mongo-ssl
+        secret:
+          secretName: mongo-ssl


### PR DESCRIPTION
This pr is for https://jira.slac.stanford.edu/browse/SCSAUS-794
The mongodb physical backup in 1.15 does not work. starting daily dump job for the time being. 
The dump job will be k8s cronjob which will run the mongodump-by-db.sh every day at 2am and keep 14 days backups.
The mongodump-by-db.sh runs mongodump database by database, so each dump is fast and failed backup for one db will be skipped. 